### PR TITLE
feat: animate headline cards

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,96 +1,69 @@
-body{
-
+body {
   margin: 0;
-  background-color: #faf5ef;
-  text-align: center;
-  color: #51eaea;
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  color: #333;
 }
-h1{
+
+h1 {
   text-align: center;
   color: #3e64ff;
-  font-size: 2rem;
+  margin-top: 1rem;
 }
-p{
-  color: white;
-}
-.heading{
 
-  height: 100px;
-  width: 100%;
-  margin-bottom: 100px;
-  background-color: #ecfcff;
+.card-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 2rem;
 }
+
 .card {
-
-
-  margin:50px 70px 50px 150px;
-
-  width: 80%;
-  height: 200px;
-
-
-}
-.card-body{
-  color: white;
-  width: 100%;
-  border: 0;
-  border-radius: 5px;
-}
-.card:hover{
-  box-shadow: 10px 10px 10px #525252;
-}
-.us-today{
-  background-color:  #ef4b4b;
-
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 280px;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  opacity: 0;
+  transform: translateY(20px);
+  animation: fadeInUp 0.5s forwards;
 }
 
-
-.yahoo{
-  background-color:  #614ad3;
-}
-.forbes{
-  background-color: #0c005a;
-
-}
-.tech-crunch{
-  background-color: #009975;
-}
-.cosmo{
-  background-color: #b824a4;
-}
-.economist{
-  background-color: #393e46;
-}
-.people{
-  background-color: #fa7d09;
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
 }
 
-.title{
-  color: white;
+.card-body {
+  padding: 1rem;
 }
-.title:hover{
-  color:#b2fcff;
-}
-/* .content:hover{
-  font-size: 1.5rem;
-} */
-#people{
-  margin-bottom:150px;
-}
-footer{
-  background-color: #ecfcff;
-  color:#3e64ff;
-  height: 100px;
 
-  margin-top: 10px;
-  text-align: center;
-  position: fixed;
-    left: 0;
-    bottom: 0;
-    width: 100%;
-
-
+.card-title {
+  color: #3e64ff;
+  font-size: 1.1rem;
+  font-weight: bold;
+  text-decoration: none;
+  display: block;
+  margin-bottom: 0.5rem;
 }
-h3{
-  padding: 30px;
+
+.card-title:hover {
+  text-decoration: underline;
+}
+
+.card-text {
+  color: #555;
+  margin: 0;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -3,13 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <title>Top US News Headlines</title>
+  <link rel="stylesheet" href="/css/styles.css" />
 </head>
 <body>
   <h1>Top US News Headlines</h1>
-  <ul>
-    <% headlines.forEach(function(item){ %>
-      <li><a href="<%= item.url %>"><%= item.site %></a>: <%= item.headline %></li>
+  <div class="card-container">
+    <% headlines.forEach(function(item, index){ %>
+      <div class="card" style="animation-delay:<%= index * 0.1 %>s">
+        <div class="card-body">
+          <a class="card-title" href="<%= item.url %>" target="_blank" rel="noopener noreferrer"><%= item.site %></a>
+          <p class="card-text"><%= item.headline %></p>
+        </div>
+      </div>
     <% }); %>
-  </ul>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- render headlines as responsive animated cards
- add modern card styles with hover and fade-in animation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688c107777848328b5d281379a0f18b0