### PR TITLE
feat: improve headline scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Install dependencies:
 npm install
 ```
 
+The scraper sends requests with a browser-like `User-Agent` header and checks
+common meta tags (`og:title` and `twitter:title`) in addition to `<h1>` and
+`<title>` elements to increase the odds of retrieving a meaningful headline.
+
 Run the application:
 
 ```

--- a/fetchHeadlines.js
+++ b/fetchHeadlines.js
@@ -4,13 +4,29 @@ const sites = require('./newsSources.json');
 
 async function scrapeSite(site) {
   try {
-    const response = await axios.get(site.url, { timeout: 10000 });
+    // Many news sites block requests that do not look like a real browser.
+    // Provide a common User-Agent and fall back to a couple of meta tags
+    // in case the page does not expose a standard <h1> element.
+    const response = await axios.get(site.url, {
+      timeout: 10000,
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      },
+    });
+
     const $ = cheerio.load(response.data);
-    let headline = $('h1').first().text().trim();
-    if (!headline) {
-      headline = $('title').first().text().trim();
-    }
-    return { site: site.name, url: site.url, headline: headline || 'No headline found' };
+
+    // Try a couple of different strategies for finding a headline
+    let headline =
+      $('meta[property="og:title"]').attr('content') ||
+      $('meta[name="twitter:title"]').attr('content') ||
+      $('h1').first().text() ||
+      $('title').first().text();
+
+    headline = headline ? headline.trim() : 'No headline found';
+    return { site: site.name, url: site.url, headline };
   } catch (err) {
     return { site: site.name, url: site.url, headline: 'Unable to fetch headline' };
   }


### PR DESCRIPTION
## Summary
- send browser-like headers to avoid blocking by some news sites
- look for headlines in common meta tags as well as h1/title elements
- document scraping approach in README

## Testing
- `node -e "const fetchHeadlines=require('./fetchHeadlines'); fetchHeadlines().then(h=>{console.log(h.slice(0,2)); process.exit();});"`

------
https://chatgpt.com/codex/tasks/task_e_688cdc1eec308328baa196ea5c06dd38